### PR TITLE
set bg height to 100vh for mobile

### DIFF
--- a/theme/styles.js
+++ b/theme/styles.js
@@ -2,7 +2,7 @@ const bgBoilerPlate = {
   content: '""',
   backgroundSize: "cover",
   backgroundPosition: "center",
-  position: "absolute",
+  position: "fixed",
   top: "0px",
   right: "0px",
   bottom: "0px",

--- a/theme/styles.js
+++ b/theme/styles.js
@@ -9,6 +9,7 @@ const bgBoilerPlate = {
   left: "0px",
   opacity: "0.1",
   zIndex: "-1",
+  height: "100vh",
 };
 
 const styles = {


### PR DESCRIPTION
Probably going to mess up on scroll because of the way mobile browsers calculate height. So, maybe a temporary fix.